### PR TITLE
Add Azure OpenAI integration

### DIFF
--- a/bridge/src/types.ts
+++ b/bridge/src/types.ts
@@ -58,7 +58,7 @@ export interface AgentEventMessage extends WebSocketMessage {
 }
 
 export interface LLMProvider {
-  id: string;         // Provider ID (e.g., 'openai', 'anthropic', or custom ID)
+  id: string;         // Provider ID (e.g., 'openai', 'anthropic', 'azure_openai', or custom ID)
   name?: string;      // Display name
   apiKey: string;     // API key
   baseUrl?: string;   // Optional base URL for custom providers

--- a/server/src/services/bridgeService.ts
+++ b/server/src/services/bridgeService.ts
@@ -6,6 +6,8 @@ import { Task, Message } from '../models';
 import { configureNanobrowser } from './nanobrowserService';
 
 const BRIDGE_URL = process.env.BRIDGE_URL || 'http://localhost:8787';
+const AZURE_OPENAI_API_KEY = process.env.AZURE_OPENAI_API_KEY || '';
+const AZURE_OPENAI_ENDPOINT = process.env.AZURE_OPENAI_ENDPOINT || '';
 
 /**
  * Agent event message interface
@@ -29,7 +31,7 @@ interface AgentEventMessage {
  */
 // Import our own types for model configuration
 interface LLMProvider {
-  id: string;         // Provider ID (e.g., 'openai', 'anthropic', or custom ID)
+  id: string;         // Provider ID (e.g., 'openai', 'anthropic', 'azure_openai', or custom ID)
   name?: string;      // Display name
   apiKey: string;     // API key
   baseUrl?: string;   // Optional base URL for custom providers

--- a/server/src/services/nanobrowserService.ts
+++ b/server/src/services/nanobrowserService.ts
@@ -3,6 +3,8 @@ import { AgentModelMessage, LLMProviderMessage } from '../../../bridge/src/types
 
 const BRIDGE_URL = process.env.BRIDGE_URL || 'http://localhost:8787';
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+const AZURE_OPENAI_API_KEY = process.env.AZURE_OPENAI_API_KEY || '';
+const AZURE_OPENAI_ENDPOINT = process.env.AZURE_OPENAI_ENDPOINT || '';
 
 // Parse model names from environment variable or use defaults
 const MODEL_NAMES = process.env.LLM_MODEL_NAMES 
@@ -23,9 +25,10 @@ const NANOBROWSER_VALIDATOR_TEMPERATURE = parseFloat(process.env.NANOBROWSER_VAL
 const NANOBROWSER_VALIDATOR_TOP_P = parseFloat(process.env.NANOBROWSER_VALIDATOR_TOP_P || '0.8');
 
 console.log(`Configuring nanobrowser with OpenAI API key: ${OPENAI_API_KEY}`);
+console.log(`Configuring nanobrowser with Azure OpenAI API key: ${AZURE_OPENAI_API_KEY}`);
 
 export async function configureNanobrowser() {
-  const providerConfig: LLMProviderMessage = {
+  const openaiProviderConfig: LLMProviderMessage = {
     type: 'llm_provider',
     action: 'create',
     provider: {
@@ -36,12 +39,32 @@ export async function configureNanobrowser() {
     }
   };
 
+  const azureProviderConfig: LLMProviderMessage = {
+    type: 'llm_provider',
+    action: 'create',
+    provider: {
+      id: 'azure_openai',
+      name: 'Azure OpenAI',
+      apiKey: AZURE_OPENAI_API_KEY,
+      baseUrl: AZURE_OPENAI_ENDPOINT,
+      modelNames: MODEL_NAMES
+    }
+  };
+
   await fetch(`${BRIDGE_URL}/provider`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify(providerConfig)
+    body: JSON.stringify(openaiProviderConfig)
+  });
+
+  await fetch(`${BRIDGE_URL}/provider`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(azureProviderConfig)
   });
 
   // wait 100ms


### PR DESCRIPTION
Add Azure OpenAI integration to the project.

* **server/src/services/nanobrowserService.ts**
  - Add Azure OpenAI API key and endpoint environment variables.
  - Log Azure OpenAI API key during configuration.
  - Add Azure OpenAI provider configuration in `configureNanobrowser` function.
  - Send Azure OpenAI provider configuration to the bridge.

* **bridge/src/types.ts**
  - Update `LLMProvider` interface to support Azure OpenAI.

* **server/src/services/bridgeService.ts**
  - Add Azure OpenAI API key and endpoint environment variables.
  - Update `LLMProvider` interface to support Azure OpenAI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/reindent/nanomachine/pull/1?shareId=8ee0e94f-62cd-4553-bbc9-2e45b50872b9).